### PR TITLE
add new columns for lat/long if 'gps' question detected; set value by gps.split(' ')[n]

### DIFF
--- a/automation/01-processForm.js
+++ b/automation/01-processForm.js
@@ -62,7 +62,9 @@ get(`${state.data.url}`, {}, state => {
 
   function questionsToColumns(questions) {
     var form = questions.filter(elt => !discards.includes(elt.type));
+
     form.forEach(obj => (obj.type = mapType[obj.type] || 'text'));
+
     form.forEach(obj => {
       // At some point we might need a list of 'question' that should be renamed, and their new values.
       // List of reserved keys in postgresql
@@ -79,6 +81,14 @@ get(`${state.data.url}`, {}, state => {
         obj.name = 'date_value';
       }
     });
+
+    form.forEach(q => {
+      if (q.name === 'gps') {
+        form.push({ name: 'latitude', type: 'float4' });
+        form.push({ name: 'longitude', type: 'float4' });
+      }
+    });
+
     form = form.map(x => {
       const name = toCamelCase(x.name) || toCamelCase(x.$autoname);
       return {

--- a/automation/02b-syncToOpenFn.js
+++ b/automation/02b-syncToOpenFn.js
@@ -118,8 +118,20 @@ each(
             if (columns[k].parentColumn)
               logical = `dataValue('${columns[k].path.join('/')}')`;
           }
+          
           if (columns[k].name === 'AnswerId') {
             mapKoboToPostgres[columns[k].name] = `dataValue('_id')`;
+          }
+
+          if (columns[k].name === 'latitude') {
+            mapKoboToPostgres[
+              columns[k].name
+            ] = `state => state.data.gps.split(' ')[0]`;
+          }
+          if (columns[k].name === 'longitude') {
+            mapKoboToPostgres[
+              columns[k].name
+            ] = `state => state.data.gps.split(' ')[1]`;
           }
         }
 


### PR DESCRIPTION
This PR addresses #126 . Before merging, @ritazagoni , can you confirm that:
1. we're happy assuming that `gps` will always be a string that's space separated and we'll pick out the items as indicated?
2. we're happy leaving the original `gps` column in there?
3. we should map these to `float4` rather than `decimal`. I saw `decimal` in the spec, but noticed that we actually were replacing `decimal` with `float4` earlier in the job.