### PR TITLE
feat: create get forms from kobo job

### DIFF
--- a/form-sharing/1-getNewKoboForms.js
+++ b/form-sharing/1-getNewKoboForms.js
@@ -1,0 +1,10 @@
+getForms({}, state => {
+  const keywords = ['price', 'prix', 'bns', 'nrgt', 'grm', 'feedback'];
+
+  const checkForKeyWords = name => {
+    return keywords.some(keyword => name.toLowerCase().includes(keyword));
+  };
+
+  state.data = state.data.results.filter(form => checkForKeyWords(form.name));
+  return state;
+});

--- a/form-sharing/1-getNewKoboForms.js
+++ b/form-sharing/1-getNewKoboForms.js
@@ -5,6 +5,6 @@ getForms({}, state => {
     return keywords.some(keyword => name.toLowerCase().includes(keyword));
   };
 
-  state.data = state.data.results.filter(form => checkForKeyWords(form.name));
+  state.koboForms = state.data.results.filter(form => checkForKeyWords(form.name));
   return state;
 });

--- a/form-sharing/2-getSheetsList.js
+++ b/form-sharing/2-getSheetsList.js
@@ -1,14 +1,16 @@
 getValues(
   '1s7K3kxzm5AlpwiALattyc7D9_aIyqWmo2ubcQIUlqlY',
-  'sheetsList of kobo forms!A:K'
+  'sheetsList of kobo forms!A:K',
+  state => {
+    const { koboForms, data } = state;
+    const [headers, ...sheetsData] = data.values;
+    const sheetsUids = sheetsData.map(row => row[0]);
+    console.log('Ignoring headers', headers);
+
+    state.filteredKoboFormsData = koboForms.filter(
+      form => !sheetsUids.includes(form.uid)
+    );
+
+    return state;
+  }
 );
-fn(state => {
-  const { koboForms} = state;
-  const googleSheetsData = state.data.values.map(row => row[0]);
-
-  state.filteredKoboFormsData = koboForms.filter(
-    form => !googleSheetsData.includes(form.uid)
-  );
-
-  return state;
-});

--- a/form-sharing/2-getSheetsList.js
+++ b/form-sharing/2-getSheetsList.js
@@ -3,10 +3,10 @@ getValues(
   'sheetsList of kobo forms!A:K'
 );
 fn(state => {
-  const koboFormsData = state.references[1];
+  const koboFormsData = state.koboForms;
   const googleSheetsData = state.data.values.map(row => row[0]);
 
-  state.data = koboFormsData.filter(
+  state.filteredKoboFormsData = koboFormsData.filter(
     form => !googleSheetsData.includes(form.uid)
   );
 

--- a/form-sharing/2-getSheetsList.js
+++ b/form-sharing/2-getSheetsList.js
@@ -3,10 +3,10 @@ getValues(
   'sheetsList of kobo forms!A:K'
 );
 fn(state => {
-  const koboFormsData = state.koboForms;
+  const { koboForms} = state;
   const googleSheetsData = state.data.values.map(row => row[0]);
 
-  state.filteredKoboFormsData = koboFormsData.filter(
+  state.filteredKoboFormsData = koboForms.filter(
     form => !googleSheetsData.includes(form.uid)
   );
 

--- a/form-sharing/2-getSheetsList.js
+++ b/form-sharing/2-getSheetsList.js
@@ -1,3 +1,14 @@
+getValues(
+  '1s7K3kxzm5AlpwiALattyc7D9_aIyqWmo2ubcQIUlqlY',
+  'sheetsList of kobo forms!A:K'
+);
 fn(state => {
-    console.log(state);
-})
+  const koboFormsData = state.references[1];
+  const googleSheetsData = state.data.values.map(row => row[0]);
+
+  state.data = koboFormsData.filter(
+    form => !googleSheetsData.includes(form.uid)
+  );
+
+  return state;
+});

--- a/form-sharing/2-getSheetsList.js
+++ b/form-sharing/2-getSheetsList.js
@@ -1,0 +1,3 @@
+fn(state => {
+    console.log(state);
+})

--- a/form-sharing/3-updateSheetsList.js
+++ b/form-sharing/3-updateSheetsList.js
@@ -1,5 +1,5 @@
 fn(state => {
-  const koboFormsData = state.filteredKoboFormsData;
+  const { filteredKoboFormsData } = state;
   const keywords = ['price', 'prix', 'bns', 'nrgt', 'grm', 'feedback'];
 
   const tagMapping = {
@@ -23,67 +23,42 @@ fn(state => {
     return tag;
   };
 
-  const createInstance = name => {
-    if (name.toLowerCase().includes('grm', 'feedback')) {
-      return '';
-    } else {
-      return 'Add manually';
-    }
-  };
+  const containsGRMFeedback = name =>
+    name.toLowerCase().includes('grm', 'feedback');
 
-  const createProjectId = name => {
-    if (name.toLowerCase().includes('grm', 'feedback')) {
-      return 'Add manually';
-    } else {
-      return '';
-    }
-  };
+  const instance = name =>
+    containsGRMFeedback(name) ? '' : 'Add manually';
 
-  const createGRMiD = name => {
-    if (name.toLowerCase().includes('grm', 'feedback')) {
-      return 'GRM ID. XX';
-    } else {
-      return '';
-    }
-  };
+  const projectId = name =>
+    containsGRMFeedback(name) ? 'Add manually' : '';
 
-  const createWorkspaceName = name => {
-    if (name.toLowerCase().includes('grm', 'feedback')) {
-      return 'Grievances';
-    } else {
-      return 'ConSoSci';
-    }
-  };
+  const grmID = name => (containsGRMFeedback(name) ? 'GRM ID. XX' : '');
 
-  const googleSheetsAppendData = [];
+  const workspaceName = name =>
+    containsGRMFeedback(name) ? 'Grievances' : 'ConSoSci';
 
-  koboFormsData.forEach(form => {
+  state.sheetsData = filteredKoboFormsData.map(form => {
     const formName = form.name;
-    const data = [
+    return [
       form.uid,
       form.name,
       createTagName(formName),
       form.owner__username,
-      createInstance(formName),
-      createProjectId(formName),
-      createGRMiD(formName),
-      createWorkspaceName(formName),
+      instance(formName),
+      projectId(formName),
+      grmID(formName),
+      workspaceName(formName),
       form.url,
       form.date_modified,
       form.date_created,
     ];
-  
-    googleSheetsAppendData.push(data);
   });
 
-  state.googleSheetsAppendData = googleSheetsAppendData
   return state;
 });
 
-appendValues(
-    {
-        spreadsheetId: '1s7K3kxzm5AlpwiALattyc7D9_aIyqWmo2ubcQIUlqlY',
-        range: 'sheetsList of kobo forms!A:K',
-        values: state.googleSheetsAppendData,
-      }
-)
+appendValues({
+  spreadsheetId: '1s7K3kxzm5AlpwiALattyc7D9_aIyqWmo2ubcQIUlqlY',
+  range: 'sheetsList of kobo forms!A:K',
+  values: state => state.sheetsData,
+});

--- a/form-sharing/3-updateSheetsList.js
+++ b/form-sharing/3-updateSheetsList.js
@@ -1,0 +1,89 @@
+fn(state => {
+  const koboFormsData = state.filteredKoboFormsData;
+  const keywords = ['price', 'prix', 'bns', 'nrgt', 'grm', 'feedback'];
+
+  const tagMapping = {
+    price: 'bns_price',
+    prix: 'bns_price',
+    bns: 'bns_survey',
+    nrgt: 'nrgt_current',
+    grm: 'grm',
+    feedback: 'grm',
+  };
+
+  const createTagName = name => {
+    let tag = '';
+    const keyword = keywords.find(keyword =>
+      name.toLowerCase().includes(keyword)
+    );
+
+    if (keyword) {
+      tag = tagMapping[keyword] || keyword;
+    }
+    return tag;
+  };
+
+  const createInstance = name => {
+    if (name.toLowerCase().includes('grm', 'feedback')) {
+      return '';
+    } else {
+      return 'Add manually';
+    }
+  };
+
+  const createProjectId = name => {
+    if (name.toLowerCase().includes('grm', 'feedback')) {
+      return 'Add manually';
+    } else {
+      return '';
+    }
+  };
+
+  const createGRMiD = name => {
+    if (name.toLowerCase().includes('grm', 'feedback')) {
+      return 'GRM ID. XX';
+    } else {
+      return '';
+    }
+  };
+
+  const createWorkspaceName = name => {
+    if (name.toLowerCase().includes('grm', 'feedback')) {
+      return 'Grievances';
+    } else {
+      return 'ConSoSci';
+    }
+  };
+
+  const googleSheetsAppendData = [];
+
+  koboFormsData.forEach(form => {
+    const formName = form.name;
+    const data = [
+      form.uid,
+      form.name,
+      createTagName(formName),
+      form.owner__username,
+      createInstance(formName),
+      createProjectId(formName),
+      createGRMiD(formName),
+      createWorkspaceName(formName),
+      form.url,
+      form.date_modified,
+      form.date_created,
+    ];
+  
+    googleSheetsAppendData.push(data);
+  });
+
+  state.googleSheetsAppendData = googleSheetsAppendData
+  return state;
+});
+
+appendValues(
+    {
+        spreadsheetId: '1s7K3kxzm5AlpwiALattyc7D9_aIyqWmo2ubcQIUlqlY',
+        range: 'sheetsList of kobo forms!A:K',
+        values: state.googleSheetsAppendData,
+      }
+)

--- a/form-sharing/4-upsertAsanaTask.js
+++ b/form-sharing/4-upsertAsanaTask.js
@@ -1,0 +1,16 @@
+
+
+fn(state => {
+    console.log(state.filteredKoboFormsData);
+    return state
+})
+
+upsertTask("1198901998266253", {
+    externalId: "name",
+    data: {
+      name: "test",
+      approval_status: "pending",
+      projects: ["1203181218738601"],
+      assignee: "1203181218738601",
+    },
+  });

--- a/form-sharing/4-upsertAsanaTask.js
+++ b/form-sharing/4-upsertAsanaTask.js
@@ -1,9 +1,7 @@
 fn(state => {
-  const today = new Date();
-
-  const futureDate = new Date(today.getTime() + 5 * 24 * 60 * 60 * 1000);
-
-  const dueDate = futureDate.toISOString().split('T')[0];
+  const dueDate = new Date(new Date().getTime() + 5 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0];
 
   state.asanaTasks = state.filteredKoboFormsData.map(form => {
     return {

--- a/form-sharing/4-upsertAsanaTask.js
+++ b/form-sharing/4-upsertAsanaTask.js
@@ -1,16 +1,14 @@
-
-
-fn(state => {
-    console.log(state.filteredKoboFormsData);
-    return state
-})
-
-upsertTask("1198901998266253", {
-    externalId: "name",
-    data: {
-      name: "test",
-      approval_status: "pending",
-      projects: ["1203181218738601"],
-      assignee: "1203181218738601",
-    },
-  });
+each(
+  '$.filteredKoboFormData[*]',
+  upsertTask('1198901998266253', state => {
+    return {
+      externalId: 'name',
+      data: {
+        name: state.filteredKoboFormData.name,
+        approval_status: 'pending',
+        projects: ['1203181218738601'],
+        assignee: '1203181218738601',
+      },
+    };
+  })
+);

--- a/form-sharing/4-upsertAsanaTask.js
+++ b/form-sharing/4-upsertAsanaTask.js
@@ -1,14 +1,28 @@
-each(
-  '$.filteredKoboFormData[*]',
-  upsertTask('1198901998266253', state => {
+fn(state => {
+  const today = new Date();
+
+  const futureDate = new Date(today.getTime() + 5 * 24 * 60 * 60 * 1000);
+
+  const dueDate = futureDate.toISOString().split('T')[0];
+
+  state.asanaTasks = state.filteredKoboFormsData.map(form => {
     return {
-      externalId: 'name',
-      data: {
-        name: state.filteredKoboFormData.name,
-        approval_status: 'pending',
-        projects: ['1203181218738601'],
-        assignee: '1203181218738601',
-      },
+      name: `New form added to OpenFn: ${form.name}`,
+      approval_status: 'pending',
+      projects: ['1198901998266253'],
+      assignee_section: '1203181218738601',
+      assignee: '473999120764595',
+      due_on: dueDate,
+      notes: `New form added to OpenFn: ${form.name}. Please review the Google Sheet and add the manual values missing: https://docs.google.com/spreadsheets/d/1s7K3kxzm5AlpwiALattyc7D9_aIyqWmo2ubcQIUlqlY/edit#gid=0`,
     };
+  });
+
+  return state;
+});
+each(
+  '$.asanaTasks[*]',
+  upsertTask('1198901998266253', {
+    externalId: 'name',
+    data: state => state.data,
   })
 );

--- a/form-sharing/workflow.json
+++ b/form-sharing/workflow.json
@@ -18,8 +18,8 @@
         "configuration": "tmp/google-sheets-creds.json",
         "expression": "2-getSheetsList.js",
         "adaptor": "googlesheets",
-        "next": {
-          "updateSheetList": "!state.error"
+        "_next": {
+          "updateSheetList": "!state.error && state.data.length !== 0"
         }
       }
       

--- a/form-sharing/workflow.json
+++ b/form-sharing/workflow.json
@@ -18,8 +18,17 @@
         "configuration": "tmp/google-sheets-creds.json",
         "expression": "2-getSheetsList.js",
         "adaptor": "googlesheets",
+        "next": {
+          "updateSheetsList": "!state.error && state.data.length !== 0"
+        }
+      },
+      {
+        "id": "updateSheetsList",
+        "configuration": "tmp/google-sheets-creds.json",
+        "expression": "3-updateSheetsList.js",
+        "adaptor": "googlesheets",
         "_next": {
-          "updateSheetList": "!state.error && state.data.length !== 0"
+          "upsertAsanaTask": "!state.error"
         }
       }
       

--- a/form-sharing/workflow.json
+++ b/form-sharing/workflow.json
@@ -28,7 +28,7 @@
         "expression": "3-updateSheetsList.js",
         "adaptor": "googlesheets",
         "next": {
-          "upsertAsanaTask": "!state.error && state.googleSheetsAppendData.length !== 0"
+          "upsertAsanaTask": "!state.error && state.sheetsData.length !== 0"
         }
       },
       {

--- a/form-sharing/workflow.json
+++ b/form-sharing/workflow.json
@@ -27,7 +27,7 @@
         "configuration": "tmp/google-sheets-creds.json",
         "expression": "3-updateSheetsList.js",
         "adaptor": "googlesheets",
-        "_next": {
+        "next": {
           "upsertAsanaTask": "!state.error && state.googleSheetsAppendData.length !== 0"
         }
       },
@@ -36,10 +36,7 @@
         "configuration": "tmp/asana-creds.json",
         "expression": "4-upsertAsanaTask.js",
         "adaptor": "asana"
-      
       }
-      
-   
     ]
   }
 }

--- a/form-sharing/workflow.json
+++ b/form-sharing/workflow.json
@@ -28,8 +28,15 @@
         "expression": "3-updateSheetsList.js",
         "adaptor": "googlesheets",
         "_next": {
-          "upsertAsanaTask": "!state.error"
+          "upsertAsanaTask": "!state.error && state.googleSheetsAppendData.length !== 0"
         }
+      },
+      {
+        "id": "upsertAsanaTask",
+        "configuration": "tmp/asana-creds.json",
+        "expression": "4-upsertAsanaTask.js",
+        "adaptor": "asana"
+      
       }
       
    

--- a/form-sharing/workflow.json
+++ b/form-sharing/workflow.json
@@ -1,0 +1,29 @@
+{
+  "options": {
+    "start": "getNewKoboForms"
+  },
+  "workflow": {
+    "steps": [
+      {
+        "id": "getNewKoboForms",
+        "configuration": "tmp/kobo-creds.json",
+        "adaptor": "kobotoolbox",
+        "expression": "1-getNewKoboForms.js",
+        "next": {
+          "getSheetsList": "!state.error && state.data.length !== 0"
+        }
+      },
+      {
+        "id": "getSheetsList",
+        "configuration": "tmp/google-sheets-creds.json",
+        "expression": "2-getSheetsList.js",
+        "adaptor": "googlesheets",
+        "next": {
+          "updateSheetList": "!state.error"
+        }
+      }
+      
+   
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Write jobs to allow a user to fetch forms from kobo, add them to Google Sheets and finally create a task on Asana

## Implementation Details

Currently a manual and tedious process is being used to update a google sheet with any new form created. To eliminate this and improve productivity, we are automating this process.


## Issues

Fixes #206 



### QA Check

**1. getNewKoboForms.js**
>configuration.json
```json
{
  "baseURL": "https://kf.kobotoolbox.org/",
  "username": "See LP",
  "password": "See LP",
}
```
> adaptor: kobotoolbox@2.1.0

**2. getSheetLists**
>adaptor: googlesheets@2.3.0
```json
{
  "accessToken": "Use 'gcloud auth print-access-token'" 
}

```
Read the following document as a quick start guide to creating your own access token
[Goole OAuth](https://blog.postman.com/how-to-access-google-apis-using-oauth-in-postman/)

**3. updateSheetsLists**
>adaptor:googlesheets@2.3.0

```json

{
  "accessToken": "Use 'gcloud auth print-access-token'" 
}
```
Refer to step _2_ for the instructions on how to get the token

**4. upsertAsanaTask**
>adaptor:asana@1.0

```json

{
    "apiVersion": "1.0",
    "token": "Use asana dev to print-access-token"
  }

```
Read the following document as a quick start guide to creating your own access token
[Asana Access Token](https://developers.asana.com/docs/personal-access-token)



