### PR TITLE
Fetch DEPLOYED sheet data and filter by historical_sync

### DIFF
--- a/bns/getArchivedFormsListFromSheets.js
+++ b/bns/getArchivedFormsListFromSheets.js
@@ -1,3 +1,23 @@
+getValues(
+  '1s7K3kxzm5AlpwiALattyc7D9_aIyqWmo2ubcQIUlqlY',
+  'wcs-bns-DEPLOYED!A:O', //get Deployed forms list from Sheet
+  state => {
+    const [headers, ...values] = state.data.values;
+
+    const mapHeaderToValue = value => {
+      return headers.reduce((obj, header) => {
+        obj[header] = value[headers.indexOf(header)];
+        return obj;
+      }, {});
+    };
+
+    state.deployedData = values
+      .map(item => mapHeaderToValue(item))
+      .filter(item => item['historical_sync'] === 'TRUE');
+
+    return state;
+  }
+);
 //== Job to be used for getting a list of "archived" Kobo forms from sheets to auto-sync  ==//
 // This can be run on-demand at any time by clicking "run" //
 getValues(
@@ -13,19 +33,16 @@ getValues(
       }, {});
     };
 
-    state.sheetsData = values
-      .filter(
-        item => item.includes('TRUE') //return forms where auto-sync = TRUE
-        //&& item.includes('bns_survey', 'nrgt_current')
-      )
-      .map(item => mapHeaderToValue(item));
+    state.archivedData = values
+      .map(item => mapHeaderToValue(item))
+      .filter(item => item['historical_sync'] === 'TRUE');
 
     return state;
   }
 );
 
 fn(state => {
-  const { sheetsData } = state;
+  const { archivedData, deployedData } = state;
 
   // Set a manual cursor if you'd like to only fetch data after this date...
   //e.g., '2023-01-01T23:51:45.491+01:00'
@@ -42,8 +59,8 @@ fn(state => {
 
   //   const cursorValue = manualCursor || dynamicCursor;
   //   console.log('Cursor value to use in query:', cursorValue);
-
-  const formsList = sheetsData.map(survey => ({
+  const combinedData = [...deployedData, ...archivedData];
+  const formsList = combinedData.map(survey => ({
     formId: survey.uid,
     tag: survey.tag,
     name: survey.name,
@@ -56,7 +73,7 @@ fn(state => {
   );
 
   state.data = {
-    surveys: sheetsData.map(survey => ({
+    surveys: combinedData.map(survey => ({
       formId: survey.uid,
       tag: survey.tag,
       name: survey.name,
@@ -65,5 +82,12 @@ fn(state => {
       //query: `&query={"end":{"$gte":"${cursorValue}"}}`, //get ALL forms for historical job
     })),
   };
+  return state;
+});
+
+//Clear final state
+fn(state => {
+  delete state.references;
+  delete state.response;
   return state;
 });

--- a/bns/getArchivedFormsListFromSheets.js
+++ b/bns/getArchivedFormsListFromSheets.js
@@ -66,7 +66,7 @@ fn(state => {
     name: survey.name,
   }));
 
-  console.log('# of archived forms detected in Sheet:: ', formsList.length);
+  console.log('# of forms detected in Sheet:: ', formsList.length);
   console.log(
     'List of forms to re-sync:: ',
     JSON.stringify(formsList, null, 2)


### PR DESCRIPTION
**Description**

Add another `getValues()` operation to fetch data from `wcs-bns-DEPLOYED` sheet and filter the results by `historical_sync` for both `wcs-bns-DEPLOYED` and `wcs-bns-ARCHIVED`.  I have combined the result into a single array the map the data to produce `state.data.surveys` with  3 records 

**Issue**
- #236 